### PR TITLE
style: 피드 카드 관련 스타일 변경

### DIFF
--- a/apps/web/src/features/feed-bookmark/ui/index.tsx
+++ b/apps/web/src/features/feed-bookmark/ui/index.tsx
@@ -56,11 +56,7 @@ export function FeedBookmarkButton({
       onClick={handleBookmarkToggle}
       {...props}
     >
-      {optimisticHasBookmarked ? (
-        <Icon name="BookMarked" className="w-5 h-5" />
-      ) : (
-        <Icon name="Bookmark" className="w-5 h-5" />
-      )}
+      <Icon name={optimisticHasBookmarked ? 'BookMarked' : 'Bookmark'} className="w-4 h-4" />
     </Button>
   );
 }

--- a/apps/web/src/features/feed-comment/ui/index.tsx
+++ b/apps/web/src/features/feed-comment/ui/index.tsx
@@ -11,10 +11,10 @@ export function FeedComment({ className, commentCount = 0, ...props }: FeedComme
       size="sm"
       type="button"
       variant="ghost"
-      className={cn(className, 'flex gap-1')}
+      className={cn(className, 'flex gap-1.5 items-center')}
       {...props}
     >
-      <Icon name="MessageSquare" className={cn('w-5 h-5')} />
+      <Icon name="MessageSquare" className={cn('w-4 h-4')} />
 
       {commentCount && <span className="text-sm">{commentCount}</span>}
     </Button>

--- a/apps/web/src/features/feed-copy-link/ui/index.tsx
+++ b/apps/web/src/features/feed-copy-link/ui/index.tsx
@@ -20,7 +20,7 @@ export function FeedCopyLinkButton({ feedId, ...props }: FeedCopyLinkButtonProps
 
   return (
     <Button size="icon" type="button" variant="ghost" onClick={handleCopyLink} {...props}>
-      <Icon name="Link" className="w-5 h-5" />
+      <Icon name="Link" className="w-4 h-4" />
     </Button>
   );
 }

--- a/apps/web/src/features/feed-down-vote/ui/index.tsx
+++ b/apps/web/src/features/feed-down-vote/ui/index.tsx
@@ -54,20 +54,16 @@ export function FeedDownvoteButton({
       disabled={isPending}
       className={cn(
         className,
-        'hover:bg-red-100 hover:text-red-500 transition-all duration-300 disabled:bg-red-100',
+        'hover:bg-red-100 hover:text-red-800 transition-all duration-300 dark:hover:bg-red-800 dark:hover:text-red-100',
         {
-          'bg-red-100': optimisticHasDownvoted,
+          'rounded-none': hasDownvoted,
+          'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100': optimisticHasDownvoted,
         }
       )}
       onClick={handleDownvote}
       {...props}
     >
-      <Icon
-        name="ArrowBigDown"
-        className={cn('w-5 h-5', {
-          'text-red-500': optimisticHasDownvoted,
-        })}
-      />
+      <Icon name="ThumbsDown" className={cn('w-4 h-4')} />
     </Button>
   );
 }

--- a/apps/web/src/features/feed-upvote/ui/index.tsx
+++ b/apps/web/src/features/feed-upvote/ui/index.tsx
@@ -74,24 +74,17 @@ export function FeedUpvoteButton({
       disabled={isPending}
       className={cn(
         className,
-        'group flex gap-1 hover:bg-green-100 hover:text-green-500 transition-all duration-300 min-w-[58px]',
+        'group flex gap-1.5 hover:bg-green-100 hover:text-green-800 transition-all duration-300 min-w-[58px] dark:hover:bg-green-800 dark:hover:text-green-100',
         {
-          'bg-green-100': optimisticHasUpvoted,
+          'rounded-none': hasUpvoted,
+          'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100': optimisticHasUpvoted,
         }
       )}
       onClick={handleUpvote}
       {...props}
     >
-      <Icon
-        name="ArrowBigUp"
-        className={cn('w-5 h-5', {
-          'text-green-500': optimisticHasUpvoted,
-        })}
-      />
-
-      <span className={cn({ 'text-green-500': optimisticHasUpvoted })}>
-        {optimisticUpvoteCount}
-      </span>
+      <Icon name="ThumbsUp" className={cn('w-4 h-4')} />
+      <span>{optimisticUpvoteCount}</span>
     </Button>
   );
 }

--- a/apps/web/src/widgets/feed-list/ui/index.tsx
+++ b/apps/web/src/widgets/feed-list/ui/index.tsx
@@ -67,7 +67,15 @@ export function FeedList() {
                   Shadcn, 생산적으로 일하기 위한 필수 도구
                 </CardTitle>
 
-                <div className="flex items-center gap-1.5 -ml-0.5">
+                <p className="text-xs text-muted-foreground tracking-tight">
+                  {new Date().toLocaleDateString('ko-KR', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </p>
+
+                <div className="flex items-center gap-1.5 -ml-1 py-1">
                   {visibleTags.map((tag) => (
                     <Badge key={tag} variant="secondary">
                       #{tag}
@@ -76,14 +84,6 @@ export function FeedList() {
 
                   <Badge variant="secondary">+{MOCK_TAGS.length - visibleTags.length}</Badge>
                 </div>
-
-                <p className="text-xs text-muted-foreground tracking-tight">
-                  {new Date().toLocaleDateString('ko-KR', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </p>
               </CardContent>
 
               <AspectRatio ratio={2 / 1}>

--- a/apps/web/src/widgets/feed-list/ui/index.tsx
+++ b/apps/web/src/widgets/feed-list/ui/index.tsx
@@ -3,7 +3,18 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { AspectRatio, Badge, Card, CardContent, CardHeader, CardTitle } from '@it-diots/shared/ui';
+import {
+  AspectRatio,
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Badge,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@it-diots/shared/ui';
 
 import { FeedBookmarkButton } from '@/features/feed-bookmark';
 import { FeedComment } from '@/features/feed-comment/ui';
@@ -12,60 +23,88 @@ import { FeedCreateDisplayButton } from '@/features/feed-create';
 import { FeedDownvoteButton } from '@/features/feed-down-vote';
 import { FeedUpvoteButton } from '@/features/feed-upvote';
 
+const MOCK_TAGS = ['webdev', 'it', 'design'];
+
 export function FeedList() {
   const { push } = useRouter();
 
+  const visibleTags = MOCK_TAGS.slice(0, 2);
+
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex justify-between items-center">
-        <b className="text-2xl font-bold">전체 피드 목록</b>
-
+      <div className="flex justify-end items-center">
         <FeedCreateDisplayButton />
       </div>
 
-      <div className="grid grid-cols-1 gap-8 md:gap-4 lg:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-8 md:gap-4 lg:grid-cols-[repeat(auto-fill,_minmax(300px,_1fr))]">
         {[1, 2, 3].map((value) => {
           return (
-            <Card className="cursor-pointer" key={value} onClick={() => push(`/feed/${value}`)}>
+            <Card
+              className="cursor-pointer overflow-hidden !gap-6.5"
+              key={value}
+              onClick={() => push(`/feed/${value}`)}
+            >
               <CardHeader>
-                <CardTitle>Shadcn: 생상적인 UI 개발의 비결</CardTitle>
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-8 w-8 rounded-full">
+                    <AvatarImage
+                      className="object-cover"
+                      src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8dXNlcnxlbnwwfHwwfHx8MA%3D%3D"
+                      alt="user image"
+                    />
+                    <AvatarFallback className="rounded-lg">USER</AvatarFallback>
+                  </Avatar>
+
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate text-sm font-semibold">{'unknown'}</span>
+                    <span className="truncate text-xs text-zinc-400">{'unknown@gmail.com'}</span>
+                  </div>
+                </div>
               </CardHeader>
 
-              <CardContent className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
-                  <Badge variant="outline">#webdev</Badge>
-                  <Badge variant="outline">#ui</Badge>
-                  <Badge variant="outline">#design</Badge>
+              <CardContent className="flex flex-col gap-3">
+                <CardTitle className="text-base tracking-tight line-clamp-1">
+                  Shadcn, 생산적으로 일하기 위한 필수 도구
+                </CardTitle>
+
+                <div className="flex items-center gap-1.5 -ml-0.5">
+                  {visibleTags.map((tag) => (
+                    <Badge key={tag} variant="secondary">
+                      #{tag}
+                    </Badge>
+                  ))}
+
+                  <Badge variant="secondary">+{MOCK_TAGS.length - visibleTags.length}</Badge>
                 </div>
 
-                <p className="text-sm text-muted-foreground">
+                <p className="text-xs text-muted-foreground tracking-tight">
                   {new Date().toLocaleDateString('ko-KR', {
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
                   })}
                 </p>
-
-                <AspectRatio ratio={16 / 9}>
-                  <Image
-                    src="https://github.com/shadcn-ui/ui/blob/main/apps/www/public/og.jpg?raw=true"
-                    alt="Shadcn: 생상적인 UI 개발의 비결"
-                    fill
-                    className="object-cover rounded-xl"
-                  />
-                </AspectRatio>
-
-                <div className="flex justify-between items-center gap-2">
-                  <div className="flex items-center border border-transparent rounded-xl bg-zinc-50 dark:bg-zinc-800 overflow-hidden">
-                    <FeedUpvoteButton feedId={1} upvoteCount={value} hasUpvoted={value === 1} />
-                    <FeedDownvoteButton feedId={1} hasDownvoted={value === 1} />
-                  </div>
-
-                  <FeedComment commentCount={value} />
-                  <FeedBookmarkButton feedId={1} hasBookmarked={value === 1} />
-                  <FeedCopyLinkButton feedId={1} />
-                </div>
               </CardContent>
+
+              <AspectRatio ratio={2 / 1}>
+                <Image
+                  src="https://github.com/shadcn-ui/ui/blob/main/apps/www/public/og.jpg?raw=true"
+                  alt="Shadcn: 생상적인 UI 개발의 비결"
+                  fill
+                  className="object-cover"
+                />
+              </AspectRatio>
+
+              <CardFooter className="justify-between">
+                <div className="flex items-center border border-transparent rounded-xl bg-zinc-50 dark:bg-zinc-800 overflow-hidden">
+                  <FeedUpvoteButton feedId={1} upvoteCount={value} hasUpvoted={value === 1} />
+                  <FeedDownvoteButton feedId={1} hasDownvoted={value === 1} />
+                </div>
+
+                <FeedComment commentCount={value} />
+                <FeedBookmarkButton feedId={1} hasBookmarked={value === 1} />
+                <FeedCopyLinkButton feedId={1} />
+              </CardFooter>
             </Card>
           );
         })}

--- a/apps/web/src/widgets/feed-list/ui/index.tsx
+++ b/apps/web/src/widgets/feed-list/ui/index.tsx
@@ -14,6 +14,10 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@it-diots/shared/ui';
 
 import { FeedBookmarkButton } from '@/features/feed-bookmark';
@@ -45,21 +49,21 @@ export function FeedList() {
               onClick={() => push(`/feed/${value}`)}
             >
               <CardHeader>
-                <div className="flex items-center gap-3">
-                  <Avatar className="h-8 w-8 rounded-full">
-                    <AvatarImage
-                      className="object-cover"
-                      src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8dXNlcnxlbnwwfHwwfHx8MA%3D%3D"
-                      alt="user image"
-                    />
-                    <AvatarFallback className="rounded-lg">USER</AvatarFallback>
-                  </Avatar>
-
-                  <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate text-sm font-semibold">{'unknown'}</span>
-                    <span className="truncate text-xs text-zinc-400">{'unknown@gmail.com'}</span>
-                  </div>
-                </div>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger className="w-fit">
+                      <Avatar className="h-8 w-8 rounded-full">
+                        <AvatarImage
+                          className="object-cover"
+                          src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8dXNlcnxlbnwwfHwwfHx8MA%3D%3D"
+                          alt="user image"
+                        />
+                        <AvatarFallback className="rounded-lg">USER</AvatarFallback>
+                      </Avatar>
+                    </TooltipTrigger>
+                    <TooltipContent>{'IT Idiots'}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </CardHeader>
 
               <CardContent className="flex flex-col gap-3">

--- a/packages/shared/src/widgets/layouts/main-layout/sidebar/sidebar-user.tsx
+++ b/packages/shared/src/widgets/layouts/main-layout/sidebar/sidebar-user.tsx
@@ -45,7 +45,7 @@ export function SidebarUser({ onSignOut, userInfo }: SidebarUserProps) {
               </Avatar>
 
               <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">{userInfo.username}</span>
+                <span className="truncate text-sm font-semibold">{userInfo.username}</span>
                 <span className="truncate text-xs">{userInfo.email}</span>
               </div>
 


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- `feed-list.tsx` 컴포넌트 내 스타일링을 수정했습니다.

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- 피드 리스트 래퍼 요소의 그리드 규칙을 변경했습니다.
  - `lg` 이상 분기에서 최소 `300px` 의 요소가 들어갈 수 있는 최대 갯수를 반복해서 채움
  - 이하 1개 (모바일 분기로 간주)
- 피드 카드의 스타일을 변경했습니다.
  - 내부 요소들의 배치를 변경했습니다.
  - 작성한 유저 아바타가 추가되었습니다.
    - 마우스를 올릴 경우, 닉네임 툴팁이 나타납니다. (툴팁 카드 디자인은 추후 생각해 볼 예정입니다.)
  - 업 보트, 다운 보트 컴포넌트 스타일이 변경됩니다. 
    - 아이콘을 보다 직관적인 엄지, 아래 엄지로 변경했습니다. 
    - 다크모드 기반의 스타일링을 추가했습니다.
    - 최종적으로 업 혹은 다운 상태가 되었을 때 `rounded-none` 처리를 했습니다.

### Before

![스크린샷 2025-03-13 오후 11 49 27](https://github.com/user-attachments/assets/dbe0813c-6bfb-4f1a-a64b-de11d2c0d56d)

### After

![스크린샷 2025-03-14 오전 12 03 49](https://github.com/user-attachments/assets/100cba8f-429f-4db0-885c-fbf0aa48ff3d)

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- 디자인 결과에 대한 리뷰도 환영입니다. 자유롭게 말씀해주세요

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [ ] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
