### PR TITLE
fix: 지원 패키지 > Supabase > Compiled Package에서 Just-in-Time Package로 변경

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -20,20 +20,20 @@
   },
   "exports": {
     "./client": {
-      "types": "./dist/client/client.d.ts",
-      "default": "./dist/client/client.js"
+      "types": "./src/client/client.ts",
+      "default": "./src/client/client.ts"
     },
     "./middleware": {
-      "types": "./dist/client/middleware.d.ts",
-      "default": "./dist/client/middleware.js"
+      "types": "./src/client/middleware.ts",
+      "default": "./src/client/middleware.ts"
     },
     "./server": {
-      "types": "./dist/client/server.d.ts",
-      "default": "./dist/client/server.js"
+      "types": "./src/client/server.ts",
+      "default": "./src/client/server.ts"
     },
     "./types": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/types/index.js"
+      "types": "./src/types/index.ts",
+      "default": "./src/types/index.ts"
     }
   }
 }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -19,21 +19,9 @@
     "supabase": "^2.12.1"
   },
   "exports": {
-    "./client": {
-      "types": "./src/client/client.ts",
-      "default": "./src/client/client.ts"
-    },
-    "./middleware": {
-      "types": "./src/client/middleware.ts",
-      "default": "./src/client/middleware.ts"
-    },
-    "./server": {
-      "types": "./src/client/server.ts",
-      "default": "./src/client/server.ts"
-    },
-    "./types": {
-      "types": "./src/types/index.ts",
-      "default": "./src/types/index.ts"
-    }
+    "./client": "./src/client/client.ts",
+    "./middleware": "./src/client/middleware.ts",
+    "./server": "./src/client/server.ts",
+    "./types": "./src/types/index.ts"
   }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)
- fix: 지원 패키지 > Supabase > Compiled Package에서 Just-in-Time Package로 변경

## 📝 상세 설명
- 별도 빌드 없이 지원 패키지의 코드를 참조 가능하도록 지원패키지 지원 방식을 수정합니다.

## ⚙️ 기타 사항
- 세팅쪽이라 리뷰 없이 머지하도록 하겠습니다!

## 🚨 Merge 전 필요 작업 (Checklist before merge)
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
